### PR TITLE
Grouping of DiagramItems using a DiagramItem as container

### DIFF
--- a/DiagramDesignerMVVM/DemoApp.Persistence.Common/DemoApp.Persistence.Common.csproj
+++ b/DiagramDesignerMVVM/DemoApp.Persistence.Common/DemoApp.Persistence.Common.csproj
@@ -43,7 +43,9 @@
     <Compile Include="Connection.cs" />
     <Compile Include="DesignerItemBase.cs" />
     <Compile Include="DiagramItem.cs" />
+    <Compile Include="GroupDesignerItem.cs" />
     <Compile Include="IDatabaseAccessService.cs" />
+    <Compile Include="IDiagramItem.cs" />
     <Compile Include="Orientation.cs" />
     <Compile Include="PersistDesignerItem.cs" />
     <Compile Include="PersitableItemBase.cs" />

--- a/DiagramDesignerMVVM/DemoApp.Persistence.Common/DesignerItemBase.cs
+++ b/DiagramDesignerMVVM/DemoApp.Persistence.Common/DesignerItemBase.cs
@@ -7,12 +7,16 @@ namespace DemoApp.Persistence.Common
 {
     public abstract class DesignerItemBase : PersistableItemBase
     {
-        public DesignerItemBase(int id, double left, double top) : base(id)
+        public DesignerItemBase(int id, double left, double top, double itemWidth, double itemHeight) : base(id)
         {
             this.Left = left;
             this.Top = top;
+            this.ItemWidth = itemWidth;
+            this.ItemHeight = itemHeight;
         }
 
+        public double ItemHeight { get; private set; }
+        public double ItemWidth { get; private set; }
         public double Left { get; private set; }
         public double Top { get; private set; }
 

--- a/DiagramDesignerMVVM/DemoApp.Persistence.Common/GroupDesignerItem.cs
+++ b/DiagramDesignerMVVM/DemoApp.Persistence.Common/GroupDesignerItem.cs
@@ -5,9 +5,10 @@ using System.Text;
 
 namespace DemoApp.Persistence.Common
 {
-    public class DiagramItem : PersistableItemBase, IDiagramItem
+    public class GroupDesignerItem : DesignerItemBase, IDiagramItem
     {
-        public DiagramItem() 
+        public GroupDesignerItem(int id, double left, double top, double itemWidth, double itemHeight) 
+            : base(id, left, top, itemWidth, itemHeight)
         {
             this.DesignerItems = new List<DiagramItemData>();
             this.ConnectionIds = new List<int>();
@@ -15,18 +16,6 @@ namespace DemoApp.Persistence.Common
 
         public List<DiagramItemData> DesignerItems { get; set; }
         public List<int> ConnectionIds { get; set; }
+
     }
-
-
-    public class DiagramItemData
-    {
-        public DiagramItemData(int itemId, Type itemType)
-        {
-            this.ItemId = itemId;
-            this.ItemType = itemType;
-        }
-
-        public int ItemId { get; set; }
-        public Type ItemType { get; set; }
-    }  
 }

--- a/DiagramDesignerMVVM/DemoApp.Persistence.Common/IDatabaseAccessService.cs
+++ b/DiagramDesignerMVVM/DemoApp.Persistence.Common/IDatabaseAccessService.cs
@@ -19,7 +19,7 @@ namespace DemoApp.Persistence.Common
         //SettingsDesignerItem is pecific to the DemoApp example
         int SaveSettingDesignerItem(SettingsDesignerItem settingsDesignerItemToSave);
         int SaveConnection(Connection connectionToSave);
-
+        int SaveGroupingDesignerItem(GroupDesignerItem groupDesignerItem);
         //Fetch methods
         IEnumerable<DiagramItem> FetchAllDiagram();
         DiagramItem FetchDiagram(int diagramId);
@@ -28,5 +28,6 @@ namespace DemoApp.Persistence.Common
         //SettingsDesignerItem is pecific to the DemoApp example
         SettingsDesignerItem FetchSettingsDesignerItem(int settingsDesignerItemId);
         Connection FetchConnection(int connectionId);
+        GroupDesignerItem FetchGroupingDesignerItem(int itemId);
     }
 }

--- a/DiagramDesignerMVVM/DemoApp.Persistence.Common/IDiagramItem.cs
+++ b/DiagramDesignerMVVM/DemoApp.Persistence.Common/IDiagramItem.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace DemoApp.Persistence.Common
+{
+    public interface IDiagramItem 
+    {
+        List<DiagramItemData> DesignerItems { get; set; }
+        List<int> ConnectionIds { get; set; }
+    }
+}

--- a/DiagramDesignerMVVM/DemoApp.Persistence.Common/PersistDesignerItem.cs
+++ b/DiagramDesignerMVVM/DemoApp.Persistence.Common/PersistDesignerItem.cs
@@ -7,7 +7,8 @@ namespace DemoApp.Persistence.Common
 {
     public class PersistDesignerItem : DesignerItemBase
     {
-        public PersistDesignerItem(int id, double left, double top, string hostUrl) : base(id, left, top)
+        public PersistDesignerItem(int id, double left, double top, double itemWidth, double itemHeight, string hostUrl) 
+            : base(id, left, top, itemWidth, itemHeight)
         {
             this.HostUrl = hostUrl;
         }

--- a/DiagramDesignerMVVM/DemoApp.Persistence.Common/SettingsDesignerItem.cs
+++ b/DiagramDesignerMVVM/DemoApp.Persistence.Common/SettingsDesignerItem.cs
@@ -7,8 +7,8 @@ namespace DemoApp.Persistence.Common
 {
     public class SettingsDesignerItem: DesignerItemBase
     {
-        public SettingsDesignerItem(int id, double left, double top, string setting1)
-            : base(id, left, top)
+        public SettingsDesignerItem(int id, double left, double top, double itemWidth, double itemHeight, string setting1)
+            : base(id, left, top, itemWidth, itemHeight)
         {
             this.Setting1 = setting1;
         }

--- a/DiagramDesignerMVVM/DemoApp.Persistence.RavenDB/DatabaseAccessService.cs
+++ b/DiagramDesignerMVVM/DemoApp.Persistence.RavenDB/DatabaseAccessService.cs
@@ -83,6 +83,11 @@ namespace DemoApp.Persistence.RavenDB
             return SaveItem(settingsDesignerItemToSave);
         }
 
+        public int SaveGroupingDesignerItem(GroupDesignerItem groupDesignerItemToSave)
+        {
+            return SaveItem(groupDesignerItemToSave);
+        }
+
         public int SaveConnection(Connection connectionToSave)
         {
             return SaveItem(connectionToSave);
@@ -120,6 +125,13 @@ namespace DemoApp.Persistence.RavenDB
             }
         }
 
+        public GroupDesignerItem FetchGroupingDesignerItem(int groupDesignerItemId)
+        {
+            using (IDocumentSession session = documentStore.OpenSession())
+            {
+                return session.Query<GroupDesignerItem>().Single(x => x.Id == groupDesignerItemId);
+            }
+        }
         public Connection FetchConnection(int connectionId)
         {
             using (IDocumentSession session = documentStore.OpenSession())

--- a/DiagramDesignerMVVM/DemoApp/App.xaml
+++ b/DiagramDesignerMVVM/DemoApp/App.xaml
@@ -1,12 +1,11 @@
-﻿
-    <Application x:Class="DemoApp.App"
+﻿<Application x:Class="DemoApp.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="Window1.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                
+
                 <!-- DiagramDesigner Dll resources, you need all of these -->
                 <ResourceDictionary Source="pack://application:,,,/DiagramDesigner;component/Resources/Styles/Shared.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/DiagramDesigner;component/Resources/Styles/ScrollBar.xaml" />
@@ -19,10 +18,11 @@
 
                 <!-- Common DemoApp Styles -->
                 <ResourceDictionary Source="Resources/Styles.xaml" />
-                
+
                 <!-- specific designer items, you should have one of these per ViewModel that you want to represent on diagram -->
                 <ResourceDictionary Source="Resources/DesignerItems/SettingsDesignerItemDataTemplate.xaml" />
                 <ResourceDictionary Source="Resources/DesignerItems/PersistDesignerItemDataTemplate.xaml" />
+                <ResourceDictionary Source="Resources/DesignerItems/GroupingDesignerItemDataTemplate.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/DiagramDesignerMVVM/DemoApp/DemoApp.csproj
+++ b/DiagramDesignerMVVM/DemoApp/DemoApp.csproj
@@ -83,6 +83,7 @@
     <Compile Include="UserControls\ToolBoxControl.xaml.cs">
       <DependentUpon>ToolBoxControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ViewModels\GroupingDesignerItemViewModel.cs" />
     <Compile Include="ViewModels\ToolBoxViewModel.cs" />
     <Compile Include="ViewModels\SettingsDesignerItemData.cs" />
     <Compile Include="ViewModels\ISupportDataChanges.cs" />
@@ -139,6 +140,10 @@
     <Page Include="Popups\PopupWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Resources\DesignerItems\GroupingDesignerItemDataTemplate.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Resources\DesignerItems\SettingsDesignerItemDataTemplate.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/DiagramDesignerMVVM/DemoApp/Resources/DesignerItems/GroupingDesignerItemDataTemplate.xaml
+++ b/DiagramDesignerMVVM/DemoApp/Resources/DesignerItems/GroupingDesignerItemDataTemplate.xaml
@@ -1,0 +1,30 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:DemoApp"
+                    xmlns:s="clr-namespace:DiagramDesigner;assembly=DiagramDesigner"
+                    xmlns:c="clr-namespace:DiagramDesigner.Controls;assembly=DiagramDesigner">
+
+    <!-- DataTemplate for DesignerCanvas look and feel -->
+    <DataTemplate DataType="{x:Type local:GroupingDesignerItemViewModel}">
+        <Grid>
+            <ItemsControl ItemsSource="{Binding Items}" 
+                          Panel.ZIndex="{Binding Items.Count}" 
+                          ItemContainerStyleSelector="{x:Static s:DesignerItemsControlItemStyleSelector.Instance}"
+                          >
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <s:DesignerCanvas AllowDrop="True"  />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+            </ItemsControl>
+
+            <Rectangle 
+                    Stretch="Fill"
+                       Width="{Binding ItemWidth}"
+                       Height="{Binding ItemHeight}"
+                    Style="{StaticResource Grouping}"
+                    Tag="Group" />
+
+        </Grid>
+    </DataTemplate>
+</ResourceDictionary>

--- a/DiagramDesignerMVVM/DemoApp/Resources/Styles.xaml
+++ b/DiagramDesignerMVVM/DemoApp/Resources/Styles.xaml
@@ -30,4 +30,22 @@
         </ControlTemplate.Triggers>
         
     </ControlTemplate>
+
+
+    <SolidColorBrush x:Key="GroupStroke" Color="#FF7C7C7C"/>
+    <LinearGradientBrush x:Key="GroupBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="#FFF4F4F4" Offset="0" />
+        <GradientStop Color="#FFD0D0D0" Offset="1" />
+    </LinearGradientBrush>
+
+    <!-- Grouping -->
+    <Style x:Key="Grouping" TargetType="Shape">
+        <Setter Property="Fill" Value="{StaticResource GroupBrush}" />
+        <Setter Property="Stroke" Value="{StaticResource GroupStroke}" />
+        <Setter Property="StrokeThickness" Value="1" />
+        <Setter Property="StrokeLineJoin" Value="Round" />
+        <Setter Property="Stretch" Value="Fill" />
+        <Setter Property="IsHitTestVisible" Value="False" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+    </Style>
 </ResourceDictionary>

--- a/DiagramDesignerMVVM/DemoApp/ViewModels/GroupingDesignerItemViewModel.cs
+++ b/DiagramDesignerMVVM/DemoApp/ViewModels/GroupingDesignerItemViewModel.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DiagramDesigner;
+using System.Windows.Input;
+using System.Collections.ObjectModel;
+
+namespace DemoApp
+{
+    public class GroupingDesignerItemViewModel : DesignerItemViewModelBase, IDiagramViewModel
+    {
+
+        private ObservableCollection<SelectableDesignerItemViewModelBase> items = new ObservableCollection<SelectableDesignerItemViewModelBase>();
+
+        public GroupingDesignerItemViewModel(int id, IDiagramViewModel parent, double left, double top)
+            : base(id, parent, left, top)
+        {
+            Init();
+        }
+
+        public GroupingDesignerItemViewModel()
+        {
+            Init();
+        }
+
+        public GroupingDesignerItemViewModel(int id, IDiagramViewModel parent, double left, double top, double itemWidth, double itemHeight) : base(id, parent, left, top, itemWidth, itemHeight)
+        {
+            Init();
+        }
+
+        public SimpleCommand AddItemCommand { get; private set; }
+        public SimpleCommand RemoveItemCommand { get; private set; }
+        public SimpleCommand ClearSelectedItemsCommand { get; private set; }
+        public SimpleCommand CreateNewDiagramCommand { get; private set; }
+
+
+
+        public ObservableCollection<SelectableDesignerItemViewModelBase> Items
+        {
+            get { return items; }
+        }
+
+        new public List<SelectableDesignerItemViewModelBase> SelectedItems
+        {
+            get { return Items.Where(x => x.IsSelected).ToList(); }
+        }
+
+        private void ExecuteAddItemCommand(object parameter)
+        {
+            if (parameter is SelectableDesignerItemViewModelBase)
+            {
+                SelectableDesignerItemViewModelBase item = (SelectableDesignerItemViewModelBase)parameter;
+                item.Parent = this;
+                items.Add(item);
+            }
+        }
+
+        private void ExecuteRemoveItemCommand(object parameter)
+        {
+            if (parameter is SelectableDesignerItemViewModelBase)
+            {
+                SelectableDesignerItemViewModelBase item = (SelectableDesignerItemViewModelBase)parameter;
+                items.Remove(item);
+            }
+        }
+
+        private void ExecuteClearSelectedItemsCommand(object parameter)
+        {
+            foreach (SelectableDesignerItemViewModelBase item in Items)
+            {
+                item.IsSelected = false;
+            }
+        }
+
+        private void ExecuteCreateNewDiagramCommand(object parameter)
+        {
+            Items.Clear();
+        }
+
+
+        private void Init()
+        {
+            AddItemCommand = new SimpleCommand(ExecuteAddItemCommand);
+            RemoveItemCommand = new SimpleCommand(ExecuteRemoveItemCommand);
+            ClearSelectedItemsCommand = new SimpleCommand(ExecuteClearSelectedItemsCommand);
+            CreateNewDiagramCommand = new SimpleCommand(ExecuteCreateNewDiagramCommand);
+
+            this.ShowConnectors = false;
+        }
+    }
+}

--- a/DiagramDesignerMVVM/DemoApp/ViewModels/PersistDesignerItemViewModel.cs
+++ b/DiagramDesignerMVVM/DemoApp/ViewModels/PersistDesignerItemViewModel.cs
@@ -11,7 +11,12 @@ namespace DemoApp
     {
         private IUIVisualizerService visualiserService;
 
-        public PersistDesignerItemViewModel(int id, DiagramViewModel parent, double left, double top, string hostUrl) : base(id,parent, left,top)
+        public PersistDesignerItemViewModel(int id, IDiagramViewModel parent, double left, double top, string hostUrl) : base(id,parent, left,top)
+        {
+            this.HostUrl = hostUrl;
+            Init();
+        }
+        public PersistDesignerItemViewModel(int id, IDiagramViewModel parent, double left, double top, double itemWidth, double itemHeight, string hostUrl) : base(id, parent, left, top, itemWidth, itemHeight)
         {
             this.HostUrl = hostUrl;
             Init();

--- a/DiagramDesignerMVVM/DemoApp/ViewModels/SettingsDesignerItemViewModel.cs
+++ b/DiagramDesignerMVVM/DemoApp/ViewModels/SettingsDesignerItemViewModel.cs
@@ -12,8 +12,16 @@ namespace DemoApp
     {
         private IUIVisualizerService visualiserService;
 
-        public SettingsDesignerItemViewModel(int id, DiagramViewModel parent, double left, double top, string setting1)
+        public SettingsDesignerItemViewModel(int id, IDiagramViewModel parent, double left, double top, string setting1)
             : base(id, parent, left, top)
+        {
+
+            this.Setting1 = setting1;
+            Init();
+        }
+
+        public SettingsDesignerItemViewModel(int id, IDiagramViewModel parent, double left, double top, double itemWidth, double itemHeight, string setting1)
+             : base(id, parent, left, top, itemWidth, itemHeight)
         {
 
             this.Setting1 = setting1;

--- a/DiagramDesignerMVVM/DemoApp/ViewModels/Window1ViewModel.cs
+++ b/DiagramDesignerMVVM/DemoApp/ViewModels/Window1ViewModel.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.Windows.Data;
 using DemoApp.Persistence.Common;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace DemoApp
 {
@@ -41,7 +42,7 @@ namespace DemoApp
             CreateNewDiagramCommand = new SimpleCommand(ExecuteCreateNewDiagramCommand);
             SaveDiagramCommand = new SimpleCommand(ExecuteSaveDiagramCommand);
             LoadDiagramCommand = new SimpleCommand(ExecuteLoadDiagramCommand);
-
+            GroupCommand = new SimpleCommand(ExecuteGroupCommand);
 
             //OrthogonalPathFinder is a pretty bad attempt at finding path points, it just shows you, you can swap this out with relative
             //ease if you wish just create a new IPathFinder class and pass it in right here
@@ -49,9 +50,11 @@ namespace DemoApp
 
         }
 
+
         public SimpleCommand DeleteSelectedItemsCommand { get; private set; }
         public SimpleCommand CreateNewDiagramCommand { get; private set; }
         public SimpleCommand SaveDiagramCommand { get; private set; }
+        public SimpleCommand GroupCommand { get; private set; }
         public SimpleCommand LoadDiagramCommand { get; private set; }
         public ToolBoxViewModel ToolBoxViewModel { get; private set; }
 
@@ -168,66 +171,36 @@ namespace DemoApp
             DiagramItem wholeDiagramToSave = null;
 
             Task<int> task = Task.Factory.StartNew<int>(() =>
+            {
+
+                if (SavedDiagramId != null)
                 {
+                    int currentSavedDiagramId = (int)SavedDiagramId.Value;
+                    wholeDiagramToSave = databaseAccessService.FetchDiagram(currentSavedDiagramId);
 
-                    if (SavedDiagramId != null)
+                    //If we have a saved diagram, we need to make sure we clear out all the removed items that
+                    //the user deleted as part of this work sesssion
+                    foreach (var itemToRemove in itemsToRemove)
                     {
-                        int currentSavedDiagramId = (int)SavedDiagramId.Value;
-                        wholeDiagramToSave = databaseAccessService.FetchDiagram(currentSavedDiagramId);
-
-                        //If we have a saved diagram, we need to make sure we clear out all the removed items that
-                        //the user deleted as part of this work sesssion
-                        foreach (var itemToRemove in itemsToRemove)
-                        {
-                            DeleteFromDatabase(wholeDiagramToSave, itemToRemove);
-                        }
-                        //start with empty collections of connections and items, which will be populated based on current diagram
-                        wholeDiagramToSave.ConnectionIds = new List<int>();
-                        wholeDiagramToSave.DesignerItems = new List<DiagramItemData>();
+                        DeleteFromDatabase(wholeDiagramToSave, itemToRemove);
                     }
-                    else
-                    {
-                        wholeDiagramToSave = new DiagramItem();
-                    }
+                    //start with empty collections of connections and items, which will be populated based on current diagram
+                    wholeDiagramToSave.ConnectionIds = new List<int>();
+                    wholeDiagramToSave.DesignerItems = new List<DiagramItemData>();
+                }
+                else
+                {
+                    wholeDiagramToSave = new DiagramItem();
+                }
 
-                    //ensure that itemsToRemove is cleared ready for any new changes within a session
-                    itemsToRemove = new List<SelectableDesignerItemViewModelBase>();
+                //ensure that itemsToRemove is cleared ready for any new changes within a session
+                itemsToRemove = new List<SelectableDesignerItemViewModelBase>();
 
-                    //Save all PersistDesignerItemViewModel
-                    foreach (var persistItemVM in DiagramViewModel.Items.OfType<PersistDesignerItemViewModel>())
-                    {
-                        PersistDesignerItem persistDesignerItem = new PersistDesignerItem(persistItemVM.Id, persistItemVM.Left, persistItemVM.Top, persistItemVM.HostUrl);
-                        persistItemVM.Id = databaseAccessService.SavePersistDesignerItem(persistDesignerItem);
-                        wholeDiagramToSave.DesignerItems.Add(new DiagramItemData(persistDesignerItem.Id, typeof(PersistDesignerItem)));
-                    }
-                    //Save all PersistDesignerItemViewModel
-                    foreach (var settingsItemVM in DiagramViewModel.Items.OfType<SettingsDesignerItemViewModel>())
-                    {
-                        SettingsDesignerItem settingsDesignerItem = new SettingsDesignerItem(settingsItemVM.Id, settingsItemVM.Left, settingsItemVM.Top, settingsItemVM.Setting1);
-                        settingsItemVM.Id = databaseAccessService.SaveSettingDesignerItem(settingsDesignerItem);
-                        wholeDiagramToSave.DesignerItems.Add(new DiagramItemData(settingsDesignerItem.Id, typeof(SettingsDesignerItem)));
-                    }
-                    //Save all connections which should now have their Connection.DataItems filled in with correct Ids
-                    foreach (var connectionVM in DiagramViewModel.Items.OfType<ConnectorViewModel>())
-                    {
-                        FullyCreatedConnectorInfo sinkConnector = connectionVM.SinkConnectorInfo as FullyCreatedConnectorInfo;
+                SavePersistDesignerItem(wholeDiagramToSave, DiagramViewModel);
 
-                        Connection connection = new Connection(
-                            connectionVM.Id,
-                            connectionVM.SourceConnectorInfo.DataItem.Id,
-                            GetOrientationFromConnector(connectionVM.SourceConnectorInfo.Orientation),
-                            GetTypeOfDiagramItem(connectionVM.SourceConnectorInfo.DataItem),
-                            sinkConnector.DataItem.Id,
-                            GetOrientationFromConnector(sinkConnector.Orientation),
-                            GetTypeOfDiagramItem(sinkConnector.DataItem));
-
-                        connectionVM.Id = databaseAccessService.SaveConnection(connection);
-                        wholeDiagramToSave.ConnectionIds.Add(connectionVM.Id);
-                    }
-
-                    wholeDiagramToSave.Id = databaseAccessService.SaveDiagram(wholeDiagramToSave);
-                    return wholeDiagramToSave.Id;
-                });
+                wholeDiagramToSave.Id = databaseAccessService.SaveDiagram(wholeDiagramToSave);
+                return wholeDiagramToSave.Id;
+            });
             task.ContinueWith((ant) =>
             {
                 int wholeDiagramToSaveId = ant.Result;
@@ -244,6 +217,52 @@ namespace DemoApp
             }, TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 
+        private void SavePersistDesignerItem(IDiagramItem wholeDiagramToSave, IDiagramViewModel diagramViewModel)
+        {
+            //Save all PersistDesignerItemViewModel
+            foreach (var persistItemVM in diagramViewModel.Items.OfType<PersistDesignerItemViewModel>())
+            {
+                PersistDesignerItem persistDesignerItem = new PersistDesignerItem(persistItemVM.Id, persistItemVM.Left, persistItemVM.Top, persistItemVM.ItemWidth, persistItemVM.ItemHeight, persistItemVM.HostUrl);
+                persistItemVM.Id = databaseAccessService.SavePersistDesignerItem(persistDesignerItem);
+                wholeDiagramToSave.DesignerItems.Add(new DiagramItemData(persistDesignerItem.Id, typeof(PersistDesignerItem)));
+            }
+            //Save all SettingsDesignerItemViewModel
+            foreach (var settingsItemVM in diagramViewModel.Items.OfType<SettingsDesignerItemViewModel>())
+            {
+                SettingsDesignerItem settingsDesignerItem = new SettingsDesignerItem(settingsItemVM.Id, settingsItemVM.Left, settingsItemVM.Top, settingsItemVM.ItemWidth, settingsItemVM.ItemHeight, settingsItemVM.Setting1);
+                settingsItemVM.Id = databaseAccessService.SaveSettingDesignerItem(settingsDesignerItem);
+                wholeDiagramToSave.DesignerItems.Add(new DiagramItemData(settingsDesignerItem.Id, typeof(SettingsDesignerItem)));
+            }
+            //Save all GroupingDesignerItemViewModel
+            foreach (var groupingItemVM in diagramViewModel.Items.OfType<GroupingDesignerItemViewModel>())
+            {
+                GroupDesignerItem groupDesignerItem = new GroupDesignerItem(groupingItemVM.Id, groupingItemVM.Left, groupingItemVM.Top, groupingItemVM.ItemWidth, groupingItemVM.ItemHeight);
+                if(groupingItemVM.Items != null && groupingItemVM.Items.Count > 0)
+                {
+                    SavePersistDesignerItem(groupDesignerItem, groupingItemVM);
+                }
+                groupingItemVM.Id = databaseAccessService.SaveGroupingDesignerItem(groupDesignerItem);
+                wholeDiagramToSave.DesignerItems.Add(new DiagramItemData(groupDesignerItem.Id, typeof(GroupDesignerItem)));
+            }
+            //Save all connections which should now have their Connection.DataItems filled in with correct Ids
+            foreach (var connectionVM in diagramViewModel.Items.OfType<ConnectorViewModel>())
+            {
+                FullyCreatedConnectorInfo sinkConnector = connectionVM.SinkConnectorInfo as FullyCreatedConnectorInfo;
+
+                Connection connection = new Connection(
+                    connectionVM.Id,
+                    connectionVM.SourceConnectorInfo.DataItem.Id,
+                    GetOrientationFromConnector(connectionVM.SourceConnectorInfo.Orientation),
+                    GetTypeOfDiagramItem(connectionVM.SourceConnectorInfo.DataItem),
+                    sinkConnector.DataItem.Id,
+                    GetOrientationFromConnector(sinkConnector.Orientation),
+                    GetTypeOfDiagramItem(sinkConnector.DataItem));
+
+                connectionVM.Id = databaseAccessService.SaveConnection(connection);
+                wholeDiagramToSave.ConnectionIds.Add(connectionVM.Id);
+            }
+        }
+
         private void ExecuteLoadDiagramCommand(object parameter)
         {
             IsBusy = true;
@@ -255,63 +274,191 @@ namespace DemoApp
             }
 
             Task<DiagramViewModel> task = Task.Factory.StartNew<DiagramViewModel>(() =>
-                {
-                    //ensure that itemsToRemove is cleared ready for any new changes within a session
-                    itemsToRemove = new List<SelectableDesignerItemViewModelBase>();
-                    DiagramViewModel diagramViewModel = new DiagramViewModel();
+            {
+                //ensure that itemsToRemove is cleared ready for any new changes within a session
+                itemsToRemove = new List<SelectableDesignerItemViewModelBase>();
+                DiagramViewModel diagramViewModel = new DiagramViewModel();
 
-                    wholeDiagramToLoad = databaseAccessService.FetchDiagram((int)SavedDiagramId.Value);
+                wholeDiagramToLoad = databaseAccessService.FetchDiagram((int)SavedDiagramId.Value);
 
-                    //load diagram items
-                    foreach (DiagramItemData diagramItemData in wholeDiagramToLoad.DesignerItems)
-                    {
-                        if (diagramItemData.ItemType == typeof(PersistDesignerItem))
-                        {
-                            PersistDesignerItem persistedDesignerItem = databaseAccessService.FetchPersistDesignerItem(diagramItemData.ItemId);
-                            PersistDesignerItemViewModel persistDesignerItemViewModel =
-                                new PersistDesignerItemViewModel(persistedDesignerItem.Id, diagramViewModel, persistedDesignerItem.Left, persistedDesignerItem.Top, persistedDesignerItem.HostUrl);
-                            diagramViewModel.Items.Add(persistDesignerItemViewModel);
-                        }
-                        if (diagramItemData.ItemType == typeof(SettingsDesignerItem))
-                        {
-                            SettingsDesignerItem settingsDesignerItem = databaseAccessService.FetchSettingsDesignerItem(diagramItemData.ItemId);
-                            SettingsDesignerItemViewModel settingsDesignerItemViewModel =
-                                new SettingsDesignerItemViewModel(settingsDesignerItem.Id, diagramViewModel, settingsDesignerItem.Left, settingsDesignerItem.Top, settingsDesignerItem.Setting1);
-                            diagramViewModel.Items.Add(settingsDesignerItemViewModel);
-                        }
-                    }
-                    //load connection items
-                    foreach (int connectionId in wholeDiagramToLoad.ConnectionIds)
-                    {
-                        Connection connection = databaseAccessService.FetchConnection(connectionId);
+                LoadPerstistDesignerItems(wholeDiagramToLoad, diagramViewModel);
 
-                        DesignerItemViewModelBase sourceItem = GetConnectorDataItem(diagramViewModel, connection.SourceId, connection.SourceType);
-                        ConnectorOrientation sourceConnectorOrientation = GetOrientationForConnector(connection.SourceOrientation);
-                        FullyCreatedConnectorInfo sourceConnectorInfo = GetFullConnectorInfo(connection.Id, sourceItem, sourceConnectorOrientation);
-
-                        DesignerItemViewModelBase sinkItem = GetConnectorDataItem(diagramViewModel, connection.SinkId, connection.SinkType);
-                        ConnectorOrientation sinkConnectorOrientation = GetOrientationForConnector(connection.SinkOrientation);
-                        FullyCreatedConnectorInfo sinkConnectorInfo = GetFullConnectorInfo(connection.Id, sinkItem, sinkConnectorOrientation);
-
-                        ConnectorViewModel connectionVM = new ConnectorViewModel(connection.Id, diagramViewModel, sourceConnectorInfo, sinkConnectorInfo);
-                        diagramViewModel.Items.Add(connectionVM);
-                    }
-
-                    return diagramViewModel;
-                });
+                return diagramViewModel;
+            });
             task.ContinueWith((ant) =>
-                {
-                    this.DiagramViewModel = ant.Result;
-                    IsBusy = false;
-                    messageBoxService.ShowInformation(string.Format("Finished loading Diagram Id : {0}", wholeDiagramToLoad.Id));
- 
-                },TaskContinuationOptions.OnlyOnRanToCompletion);
+            {
+                this.DiagramViewModel = ant.Result;
+                IsBusy = false;
+                messageBoxService.ShowInformation(string.Format("Finished loading Diagram Id : {0}", wholeDiagramToLoad.Id));
+
+            }, TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 
+        private void LoadPerstistDesignerItems(IDiagramItem wholeDiagramToLoad, IDiagramViewModel diagramViewModel)
+        {
+            //load diagram items
+            foreach (DiagramItemData diagramItemData in wholeDiagramToLoad.DesignerItems)
+            {
+                if (diagramItemData.ItemType == typeof(PersistDesignerItem))
+                {
+                    PersistDesignerItem persistedDesignerItem = databaseAccessService.FetchPersistDesignerItem(diagramItemData.ItemId);
+                    PersistDesignerItemViewModel persistDesignerItemViewModel =
+                        new PersistDesignerItemViewModel(persistedDesignerItem.Id, diagramViewModel, persistedDesignerItem.Left, persistedDesignerItem.Top, persistedDesignerItem.ItemWidth, persistedDesignerItem.ItemHeight, persistedDesignerItem.HostUrl);
+                    diagramViewModel.Items.Add(persistDesignerItemViewModel);
+                }
+                if (diagramItemData.ItemType == typeof(SettingsDesignerItem))
+                {
+                    SettingsDesignerItem settingsDesignerItem = databaseAccessService.FetchSettingsDesignerItem(diagramItemData.ItemId);
+                    SettingsDesignerItemViewModel settingsDesignerItemViewModel =
+                        new SettingsDesignerItemViewModel(settingsDesignerItem.Id, diagramViewModel, settingsDesignerItem.Left, settingsDesignerItem.Top, settingsDesignerItem.ItemWidth, settingsDesignerItem.ItemHeight, settingsDesignerItem.Setting1);
+                    diagramViewModel.Items.Add(settingsDesignerItemViewModel);
+                }
+                if (diagramItemData.ItemType == typeof(GroupDesignerItem))
+                {
+                    GroupDesignerItem groupDesignerItem = databaseAccessService.FetchGroupingDesignerItem(diagramItemData.ItemId);
+                    GroupingDesignerItemViewModel groupingDesignerItemViewModel =
+                        new GroupingDesignerItemViewModel(groupDesignerItem.Id, diagramViewModel, groupDesignerItem.Left, groupDesignerItem.Top, groupDesignerItem.ItemWidth, groupDesignerItem.ItemHeight);
+                    if(groupDesignerItem.DesignerItems != null && groupDesignerItem.DesignerItems.Count > 0)
+                    {
+                        LoadPerstistDesignerItems(groupDesignerItem, groupingDesignerItemViewModel);
+                    }
+                    diagramViewModel.Items.Add(groupingDesignerItemViewModel);
+                }
+            }
+            //load connection items
+            foreach (int connectionId in wholeDiagramToLoad.ConnectionIds)
+            {
+                Connection connection = databaseAccessService.FetchConnection(connectionId);
+
+                DesignerItemViewModelBase sourceItem = GetConnectorDataItem(diagramViewModel, connection.SourceId, connection.SourceType);
+                ConnectorOrientation sourceConnectorOrientation = GetOrientationForConnector(connection.SourceOrientation);
+                FullyCreatedConnectorInfo sourceConnectorInfo = GetFullConnectorInfo(connection.Id, sourceItem, sourceConnectorOrientation);
+
+                DesignerItemViewModelBase sinkItem = GetConnectorDataItem(diagramViewModel, connection.SinkId, connection.SinkType);
+                ConnectorOrientation sinkConnectorOrientation = GetOrientationForConnector(connection.SinkOrientation);
+                FullyCreatedConnectorInfo sinkConnectorInfo = GetFullConnectorInfo(connection.Id, sinkItem, sinkConnectorOrientation);
+
+                ConnectorViewModel connectionVM = new ConnectorViewModel(connection.Id, diagramViewModel, sourceConnectorInfo, sinkConnectorInfo);
+                diagramViewModel.Items.Add(connectionVM);
+            }
+        }
+
+        private void ExecuteGroupCommand(object parameter)
+        {
+            if (diagramViewModel.SelectedItems.Count > 0)
+            {
+                // if only one selected item is a Grouping item -> ungroup
+                if (diagramViewModel.SelectedItems[0] is GroupingDesignerItemViewModel && diagramViewModel.SelectedItems.Count == 1)
+                {
+                    GroupingDesignerItemViewModel groupObject = diagramViewModel.SelectedItems[0] as GroupingDesignerItemViewModel;
+                    foreach (var item in groupObject.Items)
+                    {
+
+                        if (item is DesignerItemViewModelBase)
+                        {
+                            DesignerItemViewModelBase tmp = (DesignerItemViewModelBase)item;
+                            tmp.Top += groupObject.Top;
+                            tmp.Left += groupObject.Left;
+                        }
+                        diagramViewModel.AddItemCommand.Execute(item);
+                        item.Parent = DiagramViewModel;
+                    }
+
+                    // "cut" connections between DiagramItems and the Group
+                    List<SelectableDesignerItemViewModelBase> GroupedItemsToRemove = new List<SelectableDesignerItemViewModelBase>();
+                    foreach (var connector in DiagramViewModel.Items.OfType<ConnectorViewModel>())
+                    {
+                        if (groupObject == connector.SourceConnectorInfo.DataItem)
+                        {
+                            GroupedItemsToRemove.Add(connector);
+                        }
+
+                        if (groupObject == ((FullyCreatedConnectorInfo)connector.SinkConnectorInfo).DataItem)
+                        {
+                            GroupedItemsToRemove.Add(connector);
+                        }
+                    }
+                    GroupedItemsToRemove.Add(groupObject);
+                    foreach (var selectedItem in GroupedItemsToRemove)
+                    {
+                        DiagramViewModel.RemoveItemCommand.Execute(selectedItem);
+                    }
+
+                }
+                else if (diagramViewModel.SelectedItems.Count > 1)
+                {
+                    double margin = 15;
+                    Rect rekt = GetBoundingRectangle(diagramViewModel.SelectedItems, margin);
+
+                    GroupingDesignerItemViewModel groupItem = new GroupingDesignerItemViewModel(0, this.diagramViewModel, rekt.Left, rekt.Top);
+                    groupItem.ItemWidth = rekt.Width;
+                    groupItem.ItemHeight = rekt.Height;
+                    foreach (var item in diagramViewModel.SelectedItems)
+                    {
+                        if (item is DesignerItemViewModelBase)
+                        {
+                            DesignerItemViewModelBase tmp = (DesignerItemViewModelBase)item;
+                            tmp.Top -= rekt.Top;
+                            tmp.Left -= rekt.Left;
+                        }
+                        groupItem.Items.Add(item);
+                        item.Parent = groupItem;
+
+                    }
+
+                    // "cut" connections between DiagramItems which are going to be grouped and
+                    // Diagramitems which are not going to be grouped
+                    List<SelectableDesignerItemViewModelBase> GroupedItemsToRemove = DiagramViewModel.SelectedItems;
+                    List<SelectableDesignerItemViewModelBase> connectionsToAlsoRemove = new List<SelectableDesignerItemViewModelBase>();
+
+                    foreach (var connector in DiagramViewModel.Items.OfType<ConnectorViewModel>())
+                    {
+                        if (ItemsToDeleteHasConnector(GroupedItemsToRemove, connector.SourceConnectorInfo))
+                        {
+                            connectionsToAlsoRemove.Add(connector);
+                        }
+
+                        if (ItemsToDeleteHasConnector(GroupedItemsToRemove, (FullyCreatedConnectorInfo)connector.SinkConnectorInfo))
+                        {
+                            connectionsToAlsoRemove.Add(connector);
+                        }
+
+                    }
+                    GroupedItemsToRemove.AddRange(connectionsToAlsoRemove);
+                    foreach (var selectedItem in GroupedItemsToRemove)
+                    {
+                        DiagramViewModel.RemoveItemCommand.Execute(selectedItem);
+                    }
+
+                    diagramViewModel.SelectedItems.Clear();
+                    this.diagramViewModel.Items.Add(groupItem);
+                }
+            }
+
+        }
+
+        private static Rect GetBoundingRectangle(IEnumerable<SelectableDesignerItemViewModelBase> items, double margin)
+        {
+            double x1 = Double.MaxValue;
+            double y1 = Double.MaxValue;
+            double x2 = Double.MinValue;
+            double y2 = Double.MinValue;
+
+            foreach (DesignerItemViewModelBase item in items.OfType<DesignerItemViewModelBase>())
+            {
+                x1 = Math.Min(item.Left - margin, x1);
+                y1 = Math.Min(item.Top - margin, y1);
+
+                x2 = Math.Max(item.Left + item.ItemWidth + margin, x2);
+                y2 = Math.Max(item.Top + item.ItemHeight + margin, y2);
+            }
+
+            return new Rect(new Point(x1, y1), new Point(x2, y2));
+        }
 
         private FullyCreatedConnectorInfo GetFullConnectorInfo(int connectorId, DesignerItemViewModelBase dataItem, ConnectorOrientation connectorOrientation)
         {
-            switch(connectorOrientation)
+            switch (connectorOrientation)
             {
                 case ConnectorOrientation.Top:
                     return dataItem.TopConnector;
@@ -334,6 +481,9 @@ namespace DemoApp
                 return typeof(PersistDesignerItem);
             if (vmType is SettingsDesignerItemViewModel)
                 return typeof(SettingsDesignerItem);
+            if (vmType is GroupingDesignerItemViewModel)
+                return typeof(GroupDesignerItem);
+            
 
             throw new InvalidOperationException(string.Format("Unknown diagram type. Currently only {0} and {1} are supported",
                 typeof(PersistDesignerItem).AssemblyQualifiedName,
@@ -342,7 +492,7 @@ namespace DemoApp
 
         }
 
-        private DesignerItemViewModelBase GetConnectorDataItem(DiagramViewModel diagramViewModel, int conectorDataItemId, Type connectorDataItemType)
+        private DesignerItemViewModelBase GetConnectorDataItem(IDiagramViewModel diagramViewModel, int conectorDataItemId, Type connectorDataItemType)
         {
             DesignerItemViewModelBase dataItem = null;
 
@@ -354,6 +504,10 @@ namespace DemoApp
             if (connectorDataItemType == typeof(SettingsDesignerItem))
             {
                 dataItem = diagramViewModel.Items.OfType<SettingsDesignerItemViewModel>().Single(x => x.Id == conectorDataItemId);
+            }
+            if (connectorDataItemType == typeof(GroupDesignerItem))
+            {
+                dataItem = diagramViewModel.Items.OfType<GroupingDesignerItemViewModel>().Single(x => x.Id == conectorDataItemId);
             }
             return dataItem;
         }
@@ -435,6 +589,6 @@ namespace DemoApp
 
 
         }
-        
+
     }
 }

--- a/DiagramDesignerMVVM/DemoApp/Window1.xaml
+++ b/DiagramDesignerMVVM/DemoApp/Window1.xaml
@@ -24,7 +24,10 @@
                     Content="Save"
                     Margin="8,0,3,0"
                     Command="{Binding SaveDiagramCommand}" />
-
+            <Button ToolTip="Ungroup/Group"
+                    Content="Ungroup/Group"
+                    Margin="8,0,3,0"
+                    Command="{Binding GroupCommand}" />
             <Label Margin="30,0,3,0"
                    VerticalAlignment="Center"
                    Content="Saved Diagrams" />

--- a/DiagramDesignerMVVM/DiagramDesigner/AttachedProperties/SelectionProps.cs
+++ b/DiagramDesignerMVVM/DiagramDesigner/AttachedProperties/SelectionProps.cs
@@ -7,7 +7,7 @@ using System.Windows.Input;
 
 namespace DiagramDesigner
 {
-    public static class SelectionProps  
+    public static class SelectionProps
     {
         #region EnabledForSelection
 
@@ -43,7 +43,7 @@ namespace DiagramDesigner
 
         static void Fe_PreviewMouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            SelectableDesignerItemViewModelBase selectableDesignerItemViewModelBase = 
+            SelectableDesignerItemViewModelBase selectableDesignerItemViewModelBase =
                 (SelectableDesignerItemViewModelBase)((FrameworkElement)sender).DataContext;
 
             if(selectableDesignerItemViewModelBase != null)
@@ -63,8 +63,33 @@ namespace DiagramDesigner
                 else if (!selectableDesignerItemViewModelBase.IsSelected)
                 {
                     foreach (SelectableDesignerItemViewModelBase item in selectableDesignerItemViewModelBase.Parent.SelectedItems)
-                        item.IsSelected = false;
+                    {
 
+                        if (item is IDiagramViewModel)
+                        {
+                            IDiagramViewModel tmp = (IDiagramViewModel)item;
+                            foreach (SelectableDesignerItemViewModelBase gItem in tmp.Items)
+                            {
+                                gItem.IsSelected = false;
+                            }
+
+                        }
+                        if (selectableDesignerItemViewModelBase.Parent is SelectableDesignerItemViewModelBase)
+                        {
+                            SelectableDesignerItemViewModelBase tmp = (SelectableDesignerItemViewModelBase)selectableDesignerItemViewModelBase.Parent;
+                            tmp.IsSelected = false;
+                        }
+                        item.IsSelected = false;
+                    }
+                    if (selectableDesignerItemViewModelBase is IDiagramViewModel)
+                    {
+                        IDiagramViewModel tmp = (IDiagramViewModel)selectableDesignerItemViewModelBase;
+                        foreach (SelectableDesignerItemViewModelBase gItem in tmp.Items)
+                        {
+                            gItem.IsSelected = false;
+                        }
+
+                    }
                     selectableDesignerItemViewModelBase.Parent.SelectedItems.Clear();
                     selectableDesignerItemViewModelBase.IsSelected = true;
                 }

--- a/DiagramDesignerMVVM/DiagramDesigner/Controls/DesignerCanvas.cs
+++ b/DiagramDesignerMVVM/DiagramDesigner/Controls/DesignerCanvas.cs
@@ -194,11 +194,12 @@ namespace DiagramDesigner
             DragObject dragObject = e.Data.GetData(typeof(DragObject)) as DragObject;
             if (dragObject != null)
             {
+
                 (DataContext as IDiagramViewModel).ClearSelectedItemsCommand.Execute(null);
                 Point position = e.GetPosition(this);
                 DesignerItemViewModelBase itemBase = (DesignerItemViewModelBase)Activator.CreateInstance(dragObject.ContentType);
-                itemBase.Left = Math.Max(0, position.X - DesignerItemViewModelBase.ItemWidth / 2);
-                itemBase.Top = Math.Max(0, position.Y - DesignerItemViewModelBase.ItemHeight / 2);
+                itemBase.Left = Math.Max(0, position.X - itemBase.ItemWidth / 2);
+                itemBase.Top = Math.Max(0, position.Y - itemBase.ItemHeight / 2);
                 itemBase.IsSelected = true;
                 (DataContext as IDiagramViewModel).AddItemCommand.Execute(itemBase);
             }

--- a/DiagramDesignerMVVM/DiagramDesigner/Controls/DragThumb.cs
+++ b/DiagramDesignerMVVM/DiagramDesigner/Controls/DragThumb.cs
@@ -39,6 +39,14 @@ namespace DiagramDesigner.Controls
                     item.Left += deltaHorizontal;
                     item.Top += deltaVertical;
 
+                    // prevent dragging items out of groupitem
+                    if (item.Parent is IDiagramViewModel && item.Parent is DesignerItemViewModelBase)
+                    {
+                        DesignerItemViewModelBase groupItem = (DesignerItemViewModelBase)item.Parent;
+                        if (item.Left + item.ItemWidth >= groupItem.ItemWidth) item.Left = groupItem.ItemWidth - item.ItemWidth;
+                        if (item.Top + item.ItemHeight >= groupItem.ItemHeight) item.Top = groupItem.ItemHeight - item.ItemHeight;
+                    }
+
                 }
                 e.Handled = true;
             }

--- a/DiagramDesignerMVVM/DiagramDesigner/Controls/ZoomBox.cs
+++ b/DiagramDesignerMVVM/DiagramDesigner/Controls/ZoomBox.cs
@@ -13,6 +13,8 @@ namespace DiagramDesigner
         private Canvas zoomCanvas;
         private Slider zoomSlider;
         private ScaleTransform scaleTransform;
+        private double mouseOffsetX = 0.0;
+        private double mouseOffsety = 0.0;
 
         #region DPs
 
@@ -98,6 +100,7 @@ namespace DiagramDesigner
 
         private void ZoomSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
+            
             double scale = e.NewValue / e.OldValue;
             double halfViewportHeight = this.ScrollViewer.ViewportHeight / 2;
             double newVerticalOffset = ((this.ScrollViewer.VerticalOffset + halfViewportHeight) * scale - halfViewportHeight);
@@ -133,7 +136,7 @@ namespace DiagramDesigner
            
             //divide the value by 10 so that it is more smooth
             double value = Math.Max(0, wheel.Delta / 10);
-            value = Math.Min(wheel.Delta, 10);
+            value = Math.Min(wheel.Delta/12, 10);
             this.zoomSlider.Value += value;
         }
 

--- a/DiagramDesignerMVVM/DiagramDesigner/Helpers/PointHelper.cs
+++ b/DiagramDesignerMVVM/DiagramDesigner/Helpers/PointHelper.cs
@@ -14,21 +14,21 @@ namespace DiagramDesigner
     {
         public static Point GetPointForConnector(FullyCreatedConnectorInfo connector)
         {
-            Point point =new Point();
+            Point point = new Point();
 
-            switch(connector.Orientation)
+            switch (connector.Orientation)
             {
                 case ConnectorOrientation.Top:
-                    point = new Point(connector.DataItem.Left + (DesignerItemViewModelBase.ItemWidth / 2), connector.DataItem.Top - (ConnectorInfoBase.ConnectorHeight));
+                    point = new Point(connector.DataItem.Left + (connector.DataItem.ItemWidth / 2), connector.DataItem.Top - (ConnectorInfoBase.ConnectorHeight));
                     break;
                 case ConnectorOrientation.Bottom:
-                    point = new Point(connector.DataItem.Left + (DesignerItemViewModelBase.ItemWidth / 2), (connector.DataItem.Top + DesignerItemViewModelBase.ItemHeight) + (ConnectorInfoBase.ConnectorHeight / 2));
+                    point = new Point(connector.DataItem.Left + (connector.DataItem.ItemWidth / 2), (connector.DataItem.Top + connector.DataItem.ItemHeight) + (ConnectorInfoBase.ConnectorHeight / 2));
                     break;
                 case ConnectorOrientation.Right:
-                    point = new Point(connector.DataItem.Left + DesignerItemViewModelBase.ItemWidth + (ConnectorInfoBase.ConnectorWidth), connector.DataItem.Top + (DesignerItemViewModelBase.ItemHeight / 2));
+                    point = new Point(connector.DataItem.Left + connector.DataItem.ItemWidth + (ConnectorInfoBase.ConnectorWidth), connector.DataItem.Top + (connector.DataItem.ItemHeight / 2));
                     break;
                 case ConnectorOrientation.Left:
-                    point = new Point(connector.DataItem.Left - ConnectorInfoBase.ConnectorWidth, connector.DataItem.Top + (DesignerItemViewModelBase.ItemHeight / 2));
+                    point = new Point(connector.DataItem.Left - ConnectorInfoBase.ConnectorWidth, connector.DataItem.Top + (connector.DataItem.ItemHeight / 2));
                     break;
             }
 

--- a/DiagramDesignerMVVM/DiagramDesigner/UserControls/DiagramControl.xaml
+++ b/DiagramDesignerMVVM/DiagramDesigner/UserControls/DiagramControl.xaml
@@ -31,9 +31,9 @@
                             <Setter Property="s:ItemConnectProps.EnabledForConnection"
                                     Value="True" />
                             <Setter Property="Width"
-                                    Value="{x:Static  s:DesignerItemViewModelBase.ItemWidth}" />
+                                    Value="{Binding ItemWidth}"/>
                             <Setter Property="Height"
-                                    Value="{x:Static  s:DesignerItemViewModelBase.ItemHeight}" />
+                                    Value="{Binding ItemHeight}"/>
                             <Setter Property="SnapsToDevicePixels"
                                     Value="True" />
                             <Setter Property="ContentTemplate">

--- a/DiagramDesignerMVVM/DiagramDesigner/ViewModels/ConnectorViewModel.cs
+++ b/DiagramDesignerMVVM/DiagramDesigner/ViewModels/ConnectorViewModel.cs
@@ -127,7 +127,7 @@ namespace DiagramDesigner
             return new ConnectorInfo()
             {
                 Orientation = orientation,
-                DesignerItemSize = new Size(DesignerItemViewModelBase.ItemWidth, DesignerItemViewModelBase.ItemHeight),
+                DesignerItemSize = new Size(sourceConnectorInfo.DataItem.ItemWidth, sourceConnectorInfo.DataItem.ItemHeight),
                 DesignerItemLeft = left,
                 DesignerItemTop = top,
                 Position = position
@@ -221,6 +221,8 @@ namespace DiagramDesigner
         {
             switch (e.PropertyName)
             {
+                case "ItemHeight":
+                case "ItemWidth":
                 case "Left":
                 case "Top":
                     SourceA = PointHelper.GetPointForConnector(this.SourceConnectorInfo);

--- a/DiagramDesignerMVVM/DiagramDesigner/ViewModels/DesignerItemViewModelBase.cs
+++ b/DiagramDesignerMVVM/DiagramDesigner/ViewModels/DesignerItemViewModelBase.cs
@@ -17,8 +17,8 @@ namespace DiagramDesigner
         private bool showConnectors = false;
         private List<FullyCreatedConnectorInfo> connectors = new List<FullyCreatedConnectorInfo>();
 
-        private static double itemWidth = 65;
-        private static double itemHeight = 65;
+        private double itemWidth = 65;
+        private double itemHeight = 65;
 
         public DesignerItemViewModelBase(int id, IDiagramViewModel parent, double left, double top) : base(id, parent)
         {
@@ -27,11 +27,51 @@ namespace DiagramDesigner
             Init();
         }
 
+        public DesignerItemViewModelBase(int id, IDiagramViewModel parent, double left, double top, double itemWidth, double itemHeight) : base(id, parent)
+        {
+            this.left = left;
+            this.top = top;
+            this.itemWidth = itemWidth;
+            this.itemHeight = itemHeight;
+            Init();
+        }
+
         public DesignerItemViewModelBase(): base()
         {
             Init();
         }
 
+        public double ItemWidth
+        {
+            get
+            {
+                return itemWidth;
+            }
+            set
+            {
+                if (itemWidth != value)
+                {
+                    itemWidth = value;
+                    NotifyChanged("ItemWidth");
+                }
+            }
+        }
+
+        public double ItemHeight
+        {
+            get
+            {
+                return itemHeight;
+            }
+            set
+            {
+                if (itemHeight != value)
+                {
+                    itemHeight = value;
+                    NotifyChanged("ItemHeight");
+                }
+            }
+        }
 
         public FullyCreatedConnectorInfo TopConnector
         {
@@ -56,17 +96,6 @@ namespace DiagramDesigner
             get { return connectors[3]; }
         }
 
-
-
-        public static double ItemWidth
-        {
-            get { return itemWidth; }
-        }
-
-        public static double ItemHeight
-        {
-            get { return itemHeight; }
-        }
 
         public bool ShowConnectors
         {
@@ -129,6 +158,6 @@ namespace DiagramDesigner
             connectors.Add(new FullyCreatedConnectorInfo(this, ConnectorOrientation.Left));
             connectors.Add(new FullyCreatedConnectorInfo(this, ConnectorOrientation.Right));
         }
-        
+
     }
 }


### PR DESCRIPTION
- Addes feature: Grouping Diagramitems
- Added persistance of grouped Diagramitems
- Bugfixed: Using mousewheel to zoom out, now only zoom out for 10%

A GroupingDesignerItem can also contain a GroupingDesignerItem. It is possible to Connect normal DesignerItem with the GroupingDesigneritem, if they have the same parent. So connecting Items which are children from DesignerCanvas and Items which are children von GroupingDesignerItem is not possible. Connecting and dragging within a Group is possible, it is not possible to drag out of the grouping boundries.

Selecting of grouped DesignerItems might seems weirded, but can easily adjust to your needs.
